### PR TITLE
Streamline export flow and add CCITT profile

### DIFF
--- a/georeferenciar_pdf_v5.py
+++ b/georeferenciar_pdf_v5.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 GeoRef PDF → GeoTIFF (PyQt6, 3 GCPs Affine)
-• Detailed LOG (terminal, panel, temp file)
-• Robust rasterization (DPI + Max MP + max long side + markups)
+• Robust rasterization (DPI + Max MP + markups)
 • Wheel zoom, pan, crosshair cursor
 • Visible, draggable markers (max 3)
 • Left-click = add point, right-click = delete nearest
@@ -14,10 +13,11 @@ GeoRef PDF → GeoTIFF (PyQt6, 3 GCPs Affine)
 NEW:
     - No lossy JPG intermediate: rasterizes PDF → NumPy array (lossless from PyMuPDF)
     - Output options:
-        * JPEG (85%, YCbCr)
-        * DEFLATE/ZIP (Predictor=2), optional 8-bit Grayscale
-    - Max long side (px) guard to avoid Google Earth texture limits
-    - Under “Export”: shows estimated size and, after “Compute”, geospatial resolution (°/px and m/px)
+        * JPEG (100%, YCbCr) [hidden]
+        * For CAD in B/W (DEFLATE 8-bit)
+        * For CAD in colour (DEFLATE)
+        * For Images (JPEG2000)
+        * TIFF 1-bit (CCITT Group 4)
 """
 
 import os
@@ -42,7 +42,7 @@ from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QFileDialog, QMessageBox,
     QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QSpinBox, QCheckBox,
     QGraphicsView, QGraphicsScene, QTableWidget, QTableWidgetItem, QHeaderView,
-    QGroupBox, QFormLayout, QStatusBar, QTextEdit, QComboBox,
+    QGroupBox, QFormLayout, QStatusBar, QComboBox,
     QGraphicsEllipseItem, QGraphicsSimpleTextItem
 )
 
@@ -80,7 +80,7 @@ def _log_excepthook(exc_type, exc_value, exc_tb):
         try:
             app = QApplication.instance()
             if app is not None:
-                msg = "An unexpected error occurred. Check the LOG.\n\n" + tb_txt[:1500]
+                msg = "An unexpected error occurred.\n\n" + tb_txt[:1500]
                 QMessageBox.critical(None, "Unhandled error", msg)
         except Exception:
             pass
@@ -88,39 +88,27 @@ def _log_excepthook(exc_type, exc_value, exc_tb):
         pass
     # Do not call default excepthook (keeps process alive).
 sys.excepthook = _log_excepthook
-LOG.info("Log file: %s", _LOG_FILE)
 
 # --------------------------- Rasterization ----------------------------
 class RasterizeError(Exception):
     pass
 
-def _compute_scales_for_limits(rect_width_pt, rect_height_pt, dpi, max_megapixels=120.0, max_long_side_px=15000):
+def _compute_scales_for_limits(rect_width_pt, rect_height_pt, dpi, max_megapixels=120.0):
     """
-    Compute effective scale to satisfy both Max MP and Max long side constraints.
+    Compute effective scale to satisfy the Max MP constraint.
     Returns (eff_scale, out_w_px, out_h_px, eff_dpi)
     """
     base_scale = max(dpi, 72) / 72.0
     w_px = rect_width_pt * base_scale
     h_px = rect_height_pt * base_scale
 
-    # 1) cap by megapixels
+    # cap by megapixels
     mp = (w_px * h_px) / 1e6
     eff_scale = base_scale
     if mp > max_megapixels:
         factor_mp = math.sqrt(max_megapixels / mp)
         eff_scale *= factor_mp
         LOG.warning("Auto downscale by MP: factor=%.3f (target ≤ %.1f MP)", factor_mp, max_megapixels)
-
-    # recompute dims
-    w_px = rect_width_pt * eff_scale
-    h_px = rect_height_pt * eff_scale
-
-    # 2) cap by long side
-    long_side = max(w_px, h_px)
-    if long_side > max_long_side_px:
-        factor_ls = max_long_side_px / long_side
-        eff_scale *= factor_ls
-        LOG.warning("Auto downscale by long side: factor=%.3f (target ≤ %d px)", factor_ls, max_long_side_px)
 
     # final dims & dpi
     w_px = rect_width_pt * eff_scale
@@ -129,14 +117,14 @@ def _compute_scales_for_limits(rect_width_pt, rect_height_pt, dpi, max_megapixel
     return eff_scale, int(round(w_px)), int(round(h_px)), eff_dpi
 
 def pdf_page_to_array_safe(pdf_path, page_index, dpi, max_megapixels=120.0,
-                           include_annots=True, max_long_side_px=15000):
+                           include_annots=True):
     """
     Rasterize a PDF page to a NumPy array (H, W, 3) in RGB, losslessly from PyMuPDF.
-    Applies guards for Max MP and Max long side.
+    Applies guard for Max MP.
     Returns (rgb_array_uint8, eff_dpi)
     """
-    LOG.info("Rasterizing PDF: %s | page: %s | dpi: %s | maxMP: %.1f | maxLongSide: %d | annots: %s",
-             pdf_path, page_index + 1, dpi, max_megapixels, max_long_side_px, include_annots)
+    LOG.info("Rasterizing PDF: %s | page: %s | dpi: %s | maxMP: %.1f | annots: %s",
+             pdf_path, page_index + 1, dpi, max_megapixels, include_annots)
 
     if not os.path.isfile(pdf_path):
         raise RasterizeError(f"PDF file not found: {pdf_path}")
@@ -154,7 +142,7 @@ def pdf_page_to_array_safe(pdf_path, page_index, dpi, max_megapixels=120.0,
         LOG.debug("PDF size (pt): width=%.2f, height=%.2f", rect.width, rect.height)
 
         eff_scale, out_w, out_h, eff_dpi = _compute_scales_for_limits(
-            rect.width, rect.height, dpi, max_megapixels, max_long_side_px
+            rect.width, rect.height, dpi, max_megapixels
         )
         LOG.debug("Final raster size: %d x %d px (eff_dpi=%.1f)", out_w, out_h, eff_dpi)
 
@@ -221,11 +209,11 @@ def compute_affine_transform(colrow_pts, lons, lats):
     return transform, rms_lon, rms_lat, ang_deg
 
 def write_geotiff_from_array(rgb_array, transform, out_tif_path, crs_epsg=4326,
-                             codec='jpeg', jpeg_quality=85, grayscale=False,
+                             codec='jpeg', jpeg_quality=100, grayscale=False,
                              tile_size=512):
     """
     Write a GeoTIFF using the given transform and CRS.
-    codec: 'jpeg' or 'deflate'
+    codec: 'jpeg', 'deflate', 'jpeg2000', or 'ccitt'
     grayscale: if True and codec == 'deflate', writes 1-band 8-bit (MINISBLACK)
     """
     if rgb_array.ndim != 3 or rgb_array.shape[2] != 3:
@@ -235,8 +223,17 @@ def write_geotiff_from_array(rgb_array, transform, out_tif_path, crs_epsg=4326,
 
     H, W, _ = rgb_array.shape
 
-    # Convert to grayscale if requested (for DEFLATE only)
-    if grayscale and codec == 'deflate':
+    # Convert to grayscale / bilevel if requested
+    if codec == 'ccitt':
+        gray = (0.299 * rgb_array[:, :, 0] +
+                0.587 * rgb_array[:, :, 1] +
+                0.114 * rgb_array[:, :, 2]).astype(np.uint8)
+        bw = (gray > 127).astype(np.uint8)
+        count = 1
+        data = bw[np.newaxis, :, :]
+        photometric = 'MINISBLACK'
+        dtype = bw.dtype
+    elif grayscale and codec == 'deflate':
         # ITU-R BT.601 luma
         gray = (0.299 * rgb_array[:, :, 0] +
                 0.587 * rgb_array[:, :, 1] +
@@ -277,11 +274,19 @@ def write_geotiff_from_array(rgb_array, transform, out_tif_path, crs_epsg=4326,
         profile.update({
             'compress': 'deflate',
             'predictor': 2,  # horizontal differencing
-            # zlevel can be set via 'zlevel': 6..9 (rasterio/gdal)
             'zlevel': 7
         })
+    elif codec == 'jpeg2000':
+        profile.update({
+            'compress': 'jpeg2000'
+        })
+    elif codec == 'ccitt':
+        profile.update({
+            'compress': 'ccitt',
+            'nbits': 1
+        })
     else:
-        raise ValueError("codec must be 'jpeg' or 'deflate'.")
+        raise ValueError("codec must be 'jpeg', 'deflate', 'jpeg2000', or 'ccitt'.")
 
     with rasterio.open(out_tif_path, 'w', **profile) as dst:
         dst.write(data)
@@ -399,24 +404,11 @@ class ImageView(QGraphicsView):
         super().mousePressEvent(event)
 
 # --------------------------- Main window -----------------------------
-class QtLogHandler(logging.Handler):
-    """Handler to send logs to the QTextEdit widget."""
-    def __init__(self, widget: QTextEdit):
-        super().__init__()
-        self.widget = widget
-        self.setFormatter(logging.Formatter("[%(asctime)s] %(levelname)s: %(message)s", "%H:%M:%S"))
-
-    def emit(self, record):
-        try:
-            msg = self.format(record)
-            self.widget.append(msg)
-        except Exception:
-            pass
 
 class GeoRefApp(QMainWindow):
     def __init__(self):
         super().__init__()
-        self.setWindowTitle("GeoRef PDF → GeoTIFF (3 GCPs, Rot/Scale) + LOG + Zoom/Drag + SPCS NAD83")
+        self.setWindowTitle("GeoRef PDF → GeoTIFF (3 GCPs, Rot/Scale) + Zoom/Drag + SPCS NAD83")
         self.resize(1360, 930)
 
         # State
@@ -447,11 +439,6 @@ class GeoRefApp(QMainWindow):
         self._build_ui()
         self._build_menu_toolbar()
         self.setStatusBar(QStatusBar())
-
-        # Connect LOG to panel
-        self.qt_log_handler = QtLogHandler(self.txt_log)
-        self.qt_log_handler.setLevel(logging.DEBUG)
-        LOG.addHandler(self.qt_log_handler)
 
         # View callbacks
         self.view.left_click_callback = self._handle_left_click
@@ -488,18 +475,29 @@ class GeoRefApp(QMainWindow):
         # Raster params
         self.spn_page = QSpinBox(); self.spn_page.setMinimum(1); self.spn_page.setMaximum(1); self.spn_page.setValue(1)
         self.spn_dpi = QSpinBox(); self.spn_dpi.setRange(72, 1200); self.spn_dpi.setValue(300)
-        self.spn_maxmp = QSpinBox(); self.spn_maxmp.setRange(10, 600); self.spn_maxmp.setValue(120)  # MP
-        self.spn_maxlong = QSpinBox(); self.spn_maxlong.setRange(2000, 60000); self.spn_maxlong.setValue(15000)  # px
+        self._max_mp = 80.0  # hidden Max Megapixels
         self.chk_ann = QCheckBox("Include annotations/markups"); self.chk_ann.setChecked(True)
+
+        # File type selection (JPEG disabled)
+        self.cmb_codec = QComboBox()
+        self.cmb_codec.addItem("JPEG (100%, YCbCr)")
+        self.cmb_codec.model().item(0).setEnabled(False)
+        self.cmb_codec.addItems([
+            "For CAD in B/W",
+            "For CAD in colour",
+            "For Images",
+            "TIFF 1-bit (CCITT Group 4)"
+        ])
+        self.cmb_codec.setCurrentIndex(1)
+        self.cmb_codec.currentIndexChanged.connect(self._update_export_info)
 
         self.btn_raster = QPushButton("Rasterize page → Image")
         self.btn_raster.clicked.connect(self._rasterize)
 
         f1.addRow(self.lbl_pdf, self.btn_pdf)
+        f1.addRow(QLabel("File Type"), self.cmb_codec)
         f1.addRow(QLabel("Page"), self.spn_page)
         f1.addRow(QLabel("DPI"), self.spn_dpi)
-        f1.addRow(QLabel("Max Megapixels"), self.spn_maxmp)
-        f1.addRow(QLabel("Max long side (px)"), self.spn_maxlong)
         f1.addRow(self.chk_ann)
         f1.addRow(self.btn_raster)
         right.addWidget(grp_pdf)
@@ -542,56 +540,28 @@ class GeoRefApp(QMainWindow):
         v_gcps.addWidget(self.btn_clear)
         right.addWidget(grp_gcps)
 
-        # Group: Transform & Output
-        grp_out = QGroupBox("Transform & Output")
+        # Group: Transform Output
+        grp_out = QGroupBox("Transform Output")
         v_out = QVBoxLayout(grp_out)
 
-        self.btn_compute = QPushButton("Compute transform (includes rotation & scale)")
-        self.btn_compute.clicked.connect(self._compute_transform)
+        self.btn_export = QPushButton("Export to GeoTIFF")
+        self.btn_export.clicked.connect(self._export_geotiff)
 
-        # Output options
-        opt_layout = QFormLayout()
-        self.cmb_codec = QComboBox()
-        self.cmb_codec.addItems(["JPEG (85%, YCbCr)", "DEFLATE (ZIP, Predictor=2)"])
-        self.cmb_codec.currentIndexChanged.connect(self._on_codec_changed)
+        v_out.addWidget(self.btn_export)
+        right.addWidget(grp_out)
+        right.addStretch()
 
-        self.chk_gray = QCheckBox("Grayscale (8-bit)")
-        self.chk_gray.setChecked(False)
-        self.chk_gray.setEnabled(False)  # enabled when DEFLATE is selected
-
-        opt_layout.addRow(QLabel("Compression"), self.cmb_codec)
-        opt_layout.addRow(self.chk_gray)
-
+        # Hidden labels (not added to layout)
         self.lbl_result = QLabel("Result: —")
         self.lbl_result.setWordWrap(True)
-
-        self.btn_export = QPushButton("Export GeoTIFF (EPSG:4326)…")
-        self.btn_export.clicked.connect(self._export_geotiff)
-        self.btn_export.setEnabled(False)
 
         self.lbl_export_info = QLabel("Output: —")  # size & resolution info
         self.lbl_export_info.setWordWrap(True)
 
-        v_out.addWidget(self.btn_compute)
-        v_out.addLayout(opt_layout)
-        v_out.addWidget(self.lbl_result)
-        v_out.addWidget(self.btn_export)
-        v_out.addWidget(self.lbl_export_info)
-        right.addWidget(grp_out)
-
-        # Group: LOG
-        grp_log = QGroupBox("LOG (also in file and console)")
-        v_log = QVBoxLayout(grp_log)
-        self.txt_log = QTextEdit(); self.txt_log.setReadOnly(True)
-        v_log.addWidget(self.txt_log)
-        right.addWidget(grp_log)
-
-        right.addStretch()
-
     def _build_menu_toolbar(self):
         act_open = QAction("Open PDF…", self); act_open.triggered.connect(self._choose_pdf)
         act_raster = QAction("Rasterize", self); act_raster.triggered.connect(self._rasterize)
-        act_export = QAction("Export GeoTIFF…", self); act_export.triggered.connect(self._export_geotiff)
+        act_export = QAction("Export to GeoTIFF…", self); act_export.triggered.connect(self._export_geotiff)
 
         tb = self.addToolBar("Main")
         tb.addAction(act_open)
@@ -668,15 +638,6 @@ class GeoRefApp(QMainWindow):
         self.lbl_epsg.setText(f"EPSG: {self.selected_epsg}")
         LOG.info("Selected CRS: EPSG:%s", self.selected_epsg)
 
-    def _on_codec_changed(self, idx):
-        text = self.cmb_codec.currentText().lower()
-        if "deflate" in text:
-            self.chk_gray.setEnabled(True)
-        else:
-            self.chk_gray.setChecked(False)
-            self.chk_gray.setEnabled(False)
-        self._update_export_info()
-
     # ------------------- Table headers -------------------
     def _set_table_headers_for_latlon(self):
         self.tbl.setColumnCount(4)
@@ -698,7 +659,7 @@ class GeoRefApp(QMainWindow):
             doc.close()
         except Exception:
             LOG.exception("Could not open PDF")
-            QMessageBox.critical(self, "Error", "Could not open the PDF. Check the LOG.")
+            QMessageBox.critical(self, "Error", "Could not open the PDF.")
             return
 
         self.pdf_path = path
@@ -707,7 +668,6 @@ class GeoRefApp(QMainWindow):
         self.spn_page.setValue(1)
         self.view.scene.clear()
         self._clear_points()
-        self.btn_export.setEnabled(False)
         self._rgb_array = None
         self._pil_img = None
         self._qimage = None
@@ -725,8 +685,7 @@ class GeoRefApp(QMainWindow):
 
         page_idx = self.spn_page.value() - 1
         dpi = self.spn_dpi.value()
-        max_mp = float(self.spn_maxmp.value())
-        max_long = int(self.spn_maxlong.value())
+        max_mp = self._max_mp
         include_ann = self.chk_ann.isChecked()
 
         # Are we re-rasterizing same PDF/page?
@@ -751,11 +710,11 @@ class GeoRefApp(QMainWindow):
 
         try:
             rgb_arr, eff_dpi = pdf_page_to_array_safe(
-                self.pdf_path, page_idx, dpi, max_mp, include_ann, max_long
+                self.pdf_path, page_idx, dpi, max_mp, include_ann
             )
         except Exception:
             LOG.exception("Rasterization failed")
-            QMessageBox.critical(self, "Error", "Rasterization failed. Check the LOG for details.")
+            QMessageBox.critical(self, "Error", "Rasterization failed.")
             return
 
         try:
@@ -775,7 +734,6 @@ class GeoRefApp(QMainWindow):
 
             # Reset output state
             self.transform = None
-            self.btn_export.setEnabled(False)
             self.lbl_result.setText("Result: —")
 
             if same_target and saved_positions:
@@ -806,7 +764,7 @@ class GeoRefApp(QMainWindow):
             LOG.info("Image loaded into view (array)")
         except Exception:
             LOG.exception("Error showing the rasterized image")
-            QMessageBox.critical(self, "Error", "Rasterized but could not show the image. Check the LOG.")
+            QMessageBox.critical(self, "Error", "Rasterized but could not show the image.")
 
         self._update_export_info()
 
@@ -899,7 +857,6 @@ class GeoRefApp(QMainWindow):
 
         # Invalidate transform/export
         self.transform = None
-        self.btn_export.setEnabled(False)
         self.lbl_result.setText("Result: —")
         self.statusBar().showMessage(f"Marker deleted. Now {len(self.markers)} point(s) remain.")
         LOG.info("Marker deleted. Remaining: %d", len(self.markers))
@@ -919,7 +876,6 @@ class GeoRefApp(QMainWindow):
                 pass
         self.markers = []
         self.transform = None
-        self.btn_export.setEnabled(False)
         self.lbl_result.setText("Result: —")
 
     # ------------------- Read GCPs -------------------
@@ -966,6 +922,7 @@ class GeoRefApp(QMainWindow):
 
     # ------------------- Compute / Export -------------------
     def _compute_transform(self):
+        self.transform = None
         if self._rgb_array is None:
             QMessageBox.warning(self, "Attention", "Rasterize a PDF page first.")
             return
@@ -981,11 +938,10 @@ class GeoRefApp(QMainWindow):
             transform, rms_lon, rms_lat, ang_deg = compute_affine_transform(colrow, lons, lats)
         except Exception:
             LOG.exception("Error computing transform")
-            QMessageBox.critical(self, "Error", "Could not compute the transform. Check the LOG.")
+            QMessageBox.critical(self, "Error", "Could not compute the transform.")
             return
 
         self.transform = transform
-        self.btn_export.setEnabled(True)
         a, b, c, d, e, f = transform.a, transform.b, transform.c, transform.d, transform.e, transform.f
         txt = (
             "Result:\n"
@@ -996,7 +952,7 @@ class GeoRefApp(QMainWindow):
             f"  Approx rotation (image x-axis → geo): {ang_deg:.3f}°"
         )
         self.lbl_result.setText(txt)
-       
+
         LOG.info("Affine transform ready. Rot≈ %.3f° | RMS: lon=%.2e°, lat=%.2e°",
                  ang_deg, rms_lon, rms_lat)
 
@@ -1004,11 +960,8 @@ class GeoRefApp(QMainWindow):
         self._update_export_info()
 
     def _export_geotiff(self):
-        if self.transform is None:
-            QMessageBox.warning(self, "Attention", "Compute the transform first.")
-            return
-        if self._rgb_array is None:
-            QMessageBox.warning(self, "Attention", "No rasterized image available.")
+        self._compute_transform()
+        if self.transform is None or self._rgb_array is None:
             return
 
         base_sug = "georef.tif"
@@ -1023,19 +976,34 @@ class GeoRefApp(QMainWindow):
             return
 
         try:
-            codec = 'jpeg' if self.cmb_codec.currentIndex() == 0 else 'deflate'
-            grayscale = self.chk_gray.isChecked()
+            idx = self.cmb_codec.currentIndex()
+            if idx == 0:
+                codec = 'jpeg'
+                grayscale = False
+            elif idx == 1:
+                codec = 'deflate'
+                grayscale = True
+            elif idx == 2:
+                codec = 'deflate'
+                grayscale = False
+            elif idx == 3:
+                codec = 'jpeg2000'
+                grayscale = False
+            else:
+                codec = 'ccitt'
+                grayscale = True
+
             write_geotiff_from_array(
                 self._rgb_array, self.transform, out_path,
-                crs_epsg=4326, codec=codec, grayscale=grayscale
+                crs_epsg=4326, codec=codec, grayscale=grayscale, jpeg_quality=100
             )
             QMessageBox.information(
                 self, "Done",
-                f"GeoTIFF created:\n{out_path}\n\nLog: {_LOG_FILE}"
+                f"GeoTIFF created:\n{out_path}"
             )
         except Exception:
             LOG.exception("Error exporting GeoTIFF")
-            QMessageBox.critical(self, "Error", "Could not write the GeoTIFF. Check the LOG.")
+            QMessageBox.critical(self, "Error", "Could not write the GeoTIFF.")
 
     # ------------------- Export info -------------------
     def _estimate_tif_sizes_mb(self, w, h, bands=3, dtype_bytes=1):
@@ -1052,7 +1020,8 @@ class GeoRefApp(QMainWindow):
         w = self._pixmap.width()
         h = self._pixmap.height()
         bands = 3
-        if self.cmb_codec.currentIndex() == 1 and self.chk_gray.isChecked():
+        idx = self.cmb_codec.currentIndex()
+        if idx in (1, 4):
             bands = 1
         uncmp, est_min, est_max = self._estimate_tif_sizes_mb(w, h, bands=bands)
         txt = (f"Output (image): {w}×{h} px, {bands} band(s), uint8.\n"


### PR DESCRIPTION
## Summary
- Group file type choices under PDF → Image with JPEG hidden and renamed profiles
- Run transform automatically from a single "Export to GeoTIFF" button
- Support CCITT Group 4 compression and fix max megapixel at 80 in the background

## Testing
- `python3 -m py_compile georeferenciar_pdf_v5.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8a615de548320871bcbb6eae0574b